### PR TITLE
feat: 更新倒计时预设按钮的时间选项

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,11 +136,11 @@
                     </div>
                 </div>
                 <div class="preset-buttons">
-                    <button class="preset-btn" data-hours="0" data-minutes="5" data-seconds="0">05:00</button>
-                    <button class="preset-btn" data-hours="0" data-minutes="15" data-seconds="0">15:00</button>
-                    <button class="preset-btn" data-hours="0" data-minutes="25" data-seconds="0">25:00</button>
-                    <button class="preset-btn" data-hours="0" data-minutes="45" data-seconds="0">45:00</button>
-                    <button class="preset-btn" data-hours="1" data-minutes="0" data-seconds="0">01:00:00</button>
+                    <button class="preset-btn" data-hours="0" data-minutes="10" data-seconds="0">10:00</button>
+                    <button class="preset-btn" data-hours="0" data-minutes="30" data-seconds="0">30:00</button>
+                    <button class="preset-btn" data-hours="1" data-minutes="0" data-seconds="0">60:00</button>
+                    <button class="preset-btn" data-hours="1" data-minutes="15" data-seconds="0">01:15:00</button>
+                    <button class="preset-btn" data-hours="2" data-minutes="0" data-seconds="0">02:00:00</button>
                 </div>
                 <button id="countdown-confirm" class="confirm-btn">确认</button>
             </div>


### PR DESCRIPTION
将原有的5/15/25/45分钟和1小时预设改为10/30分钟、1小时、1小时15分钟和2小时预设，以提供更合理的常用时间选项